### PR TITLE
Make batch consumer services public

### DIFF
--- a/DependencyInjection/OldSoundRabbitMqExtension.php
+++ b/DependencyInjection/OldSoundRabbitMqExtension.php
@@ -394,6 +394,7 @@ class OldSoundRabbitMqExtension extends Extension
             }
 
             $definition
+                ->setPublic(true)
                 ->addTag('old_sound_rabbit_mq.base_amqp')
                 ->addTag('old_sound_rabbit_mq.batch_consumer')
                 ->addMethodCall('setTimeoutWait', array($consumer['timeout_wait']))


### PR DESCRIPTION
Batch consumer services must be public too. Else they are not accessible from console command. Caught 'service or alias has been removed or inlined when the container was compiled'